### PR TITLE
Whitelist of paths to push

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,13 +19,18 @@ pog.pog {
       description = "The prefix to use in conjunction with system string when pinning paths";
       argument = "PREFIX";
     }
+    {
+      name = "derivations";
+      description = "The list of derivations to do whitelisted cachix push and pin";
+      argument = "DERIVATIONS";
+    }
   ];
   runtimeInputs = [ jq cachix git ];
   strict = true;
   script = helpers: ''
     blue "Parsing omnix JSON (subflake=$subflake)"
-     
-    STORE_PATHS=$(jq -r --arg prefix "$prefix" --arg name "$subflake" -f ${./script.jq})
+
+    STORE_PATHS=$(jq -r --arg prefix "$prefix" --arg name "$subflake" --arg derivations "$derivations" -f ${./script.jq})
 
     green "Pushing to https://''${cache}.cachix.org"
     echo "$STORE_PATHS" | jq -r --arg cache "$cache" '"cachix push \($cache) \(values | join(" "))"' | sh

--- a/script.jq
+++ b/script.jq
@@ -3,10 +3,21 @@
 # Arguments:
 # - $name: the subflake to use
 # - $prefix: the prefix to use (usually git branch)
+# - $derivations: optional list of names to filter by (if empty, all names are included)
+
+def in_list($item; $derivations):
+    ($derivations | split(" ")) | contains([$item]);
 
 if (.systems | length) != 1 
     then error("systems array must have exactly 1 element") 
-    else .systems[0] as $sys 
-        | .result.[$name].build.byName 
-        | with_entries(.key = "\($prefix)-\($sys)-" + .key) 
+    else .systems[0] as $sys
+        | $derivations as $drvs
+        | .result[$name].build.byName
+        | with_entries(
+            select(
+                ($drvs | length) == 0 or    # Include all if list is empty
+                (.key | in_list(.; $drvs))  # Or if key is in derivations
+            )
+            | .key = "\($prefix)-\($sys)-" + .key
+        )
 end


### PR DESCRIPTION
Resolves #10 

Example command:

`nix run github:rsrohitsingh682/cachix-push/add-option-derivations -- --cache mycache --subflake omnix --prefix "$(git branch --show-current)" --names "omnix-cli omnix-devshell" < om.json`

This will push and pin only `omnix-cli` and `omnix-devshell` flake outputs.